### PR TITLE
Fixed an issue regarding Eternatus and Lunala

### DIFF
--- a/mashups/official/gen8stabnmega.tour
+++ b/mashups/official/gen8stabnmega.tour
@@ -1,5 +1,5 @@
 /tour new [Gen 8] Mix and Mega, Elimination
-/tour rules STABmons Move Legality, *Acupressure, *Belly Drum, *Bolt Beak, *Boomburst, *Double Iron Bash, *Extreme Speed, *Fishious Rend, *Geomancy,*Lovely Kiss, *Shell Smash, *Shift Gear, *Spore, *Thousand Arrows, *Transform, *V-create, *Wicked Blow, +Eternatus, +Lunala, *Eternatus, *Lunala
+/tour rules STABmons Move Legality, *Acupressure, *Belly Drum, *Bolt Beak, *Boomburst, *Double Iron Bash, *Extreme Speed, *Fishious Rend, *Geomancy,*Lovely Kiss, *Shell Smash, *Shift Gear, *Spore, *Thousand Arrows, *Transform, *V-create, *Wicked Blow
 /tour autostart 10
 /tour autodq 4
 /tour name [Gen 8] STABmons Mix and Mega


### PR DESCRIPTION
Removing Eternatus and Lunala as both of them are unbanned in base Mix and Mega. "+Eternatus" and "+Lunala" lead them to be able to Mega Evolve. The added restriction didn't have an effect similar to what i experience on Mix and Mega Tier Shift code